### PR TITLE
Remove fastclick (closes #2245) (#2253)

### DIFF
--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -124,13 +124,5 @@
       })
     })
     </script>
-
-    <!-- fastclick -->
-    <script src="//cdnjs.cloudflare.com/ajax/libs/fastclick/1.0.6/fastclick.min.js"></script>
-    <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      FastClick.attach(document.body)
-    }, false)
-    </script>
   </body>
 </html>


### PR DESCRIPTION
The use of fastclick is officially discouraged.